### PR TITLE
Update to 8-2019-q3-update release

### DIFF
--- a/arm-gcc-bin.rb
+++ b/arm-gcc-bin.rb
@@ -3,9 +3,9 @@ require 'formula'
 class ArmGccBin < Formula
 
     homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm'
-    url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-mac.tar.bz2'
-    sha256 '0b528ed24db9f0fa39e5efdae9bcfc56bf9e07555cb267c70ff3fee84ec98460'
-    version '8-2018-q4-major'
+    url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2'
+    sha256 'fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085'
+    version '8-2019-q3-update'
 
     def install
         bin.install Dir["bin/*"]


### PR DESCRIPTION
Was released today, a few days late, this should have been the Q2 release:
https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads

cc @jpommerening @ladislas @leojrfs