### PR TITLE
Latest version is not available at the moment

### DIFF
--- a/arm-gcc-bin.rb
+++ b/arm-gcc-bin.rb
@@ -3,7 +3,7 @@ require 'formula'
 class ArmGccBin < Formula
 
     homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm'
-    url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2'
+    url 'https://web.archive.org/web/20191015145024if_/https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2'
     sha256 'fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085'
     version '8-2019-q3-update'
 


### PR DESCRIPTION
For some reason, the CDN responsible for providing the tarball for 8-2019-q3-update is not allowing downloads for macOS (or any other OS), so I replaced it with a web.archive.org archive from October 15th (same sha hash and all)

Just submitting this PR in case anyone else is having this problem, and need to get arm-gcc-bin.