### PR TITLE
Add back 8-2019-q3-update as a separate formula

### DIFF
--- a/arm-gcc-bin@8.rb
+++ b/arm-gcc-bin@8.rb
@@ -1,12 +1,12 @@
 require 'formula'
 
-class ArmGccBin < Formula
+class ArmGccBinAT8 < Formula
     desc 'GNU Arm Embedded Toolchain - Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors'
     homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm'
 
-    url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2'
-    sha256 '1249f860d4155d9c3ba8f30c19e7a88c5047923cea17e0d08e633f12408f01f0'
-    version '9-2019-q4-major'
+    url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2'
+    sha256 'fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085'
+    version '8-2019-q3-update'
 
     def install
         bin.install Dir["bin/*"]

--- a/arm-gcc-bin@8.rb
+++ b/arm-gcc-bin@8.rb
@@ -8,6 +8,8 @@ class ArmGccBinAT8 < Formula
     sha256 'fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085'
     version '8-2019-q3-update'
 
+    keg_only "This formula may interfere with another version of arm-gcc-bin. This is useful if you want to have multiple versions of arm-gcc-bin installed on the same machine."
+
     def install
         bin.install Dir["bin/*"]
         prefix.install Dir["arm-none-eabi", "lib", "share"]

--- a/arm-gcc-bin@8.rb
+++ b/arm-gcc-bin@8.rb
@@ -8,7 +8,7 @@ class ArmGccBinAT8 < Formula
     sha256 'fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085'
     version '8-2019-q3-update'
 
-    keg_only "it may interfere with another version of arm-gcc-bin. This is useful if you want to have multiple versions installed on the same machine."
+    keg_only "it may interfere with another version of arm-gcc-bin. This is useful if you want to have multiple versions installed on the same machine"
 
     def install
         bin.install Dir["bin/*"]

--- a/arm-gcc-bin@8.rb
+++ b/arm-gcc-bin@8.rb
@@ -8,7 +8,7 @@ class ArmGccBinAT8 < Formula
     sha256 'fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085'
     version '8-2019-q3-update'
 
-    keg_only "This formula may interfere with another version of arm-gcc-bin. This is useful if you want to have multiple versions of arm-gcc-bin installed on the same machine."
+    keg_only "it may interfere with another version of arm-gcc-bin. This is useful if you want to have multiple versions installed on the same machine."
 
     def install
         bin.install Dir["bin/*"]


### PR DESCRIPTION
Added `arm-gcc-bin@8`, and fixed the version string for the unversioned formula.
Possibly needs an `arm-gcc-bin@9` alias?