### PR TITLE
RFC: keep mainstream toolchain versioning format

### DIFF
--- a/Aliases/arm-gcc-bin
+++ b/Aliases/arm-gcc-bin
@@ -1,1 +1,1 @@
-../Formula/arm-gcc-bin@10.rb
+../Formula/arm-gcc-bin@10-2020-q4-major.rb

--- a/Aliases/arm-gcc-bin@10
+++ b/Aliases/arm-gcc-bin@10
@@ -1,0 +1,1 @@
+../Formula/arm-gcc-bin@10-2020-q4-major.rb

--- a/Aliases/arm-gcc-bin@8
+++ b/Aliases/arm-gcc-bin@8
@@ -1,0 +1,1 @@
+../Formula/arm-gcc-bin@8-2019-q3-update.rb

--- a/Aliases/arm-gcc-bin@9
+++ b/Aliases/arm-gcc-bin@9
@@ -1,0 +1,1 @@
+../Formula/arm-gcc-bin@9-2020-q2-update.rb

--- a/Formula/arm-gcc-bin@10-2020-q4-major.rb
+++ b/Formula/arm-gcc-bin@10-2020-q4-major.rb
@@ -1,4 +1,4 @@
-class ArmGccBinAT10 < Formula
+class ArmGccBinAT102020Q4Major < Formula
   desc "Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors"
   homepage "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm"
   url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-mac.tar.bz2"

--- a/Formula/arm-gcc-bin@8-2019-q3-update.rb
+++ b/Formula/arm-gcc-bin@8-2019-q3-update.rb
@@ -1,9 +1,9 @@
-class ArmGccBinAT9 < Formula
+class ArmGccBinAT82019Q3Update < Formula
   desc "Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors"
   homepage "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm"
-  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-mac.tar.bz2"
-  version "9-2020-q2-update"
-  sha256 "bbb9b87e442b426eca3148fa74705c66b49a63f148902a0ea46f676ec24f9ac6"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2"
+  version "8-2019-q3-update"
+  sha256 "fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085"
 
   keg_only <<~EOS
     it may interfere with another version of arm-gcc-bin.

--- a/Formula/arm-gcc-bin@9-2019-q4-major.rb
+++ b/Formula/arm-gcc-bin@9-2019-q4-major.rb
@@ -1,0 +1,17 @@
+class ArmGccBinAT92019Q4Major < Formula
+  desc "Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors"
+  homepage "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2"
+  version "9-2019-q4-major"
+  sha256 "1249f860d4155d9c3ba8f30c19e7a88c5047923cea17e0d08e633f12408f01f0"
+
+  keg_only <<~EOS
+    it may interfere with another version of arm-gcc-bin.
+    This is useful if you want to have multiple versions installed
+  EOS
+
+  def install
+    bin.install Dir["bin/*"]
+    prefix.install Dir["arm-none-eabi", "lib", "share"]
+  end
+end

--- a/Formula/arm-gcc-bin@9-2020-q2-update.rb
+++ b/Formula/arm-gcc-bin@9-2020-q2-update.rb
@@ -1,9 +1,9 @@
-class ArmGccBinAT8 < Formula
+class ArmGccBinAT92020Q2Update < Formula
   desc "Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors"
   homepage "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm"
-  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2"
-  version "8-2019-q3-update"
-  sha256 "fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-mac.tar.bz2"
+  version "9-2020-q2-update"
+  sha256 "bbb9b87e442b426eca3148fa74705c66b49a63f148902a0ea46f676ec24f9ac6"
 
   keg_only <<~EOS
     it may interfere with another version of arm-gcc-bin.

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,4 @@
+{
+  "arm-gcc-bin@8": "arm-gcc-bin@8-2019-q3-update",
+  "arm-gcc-bin@9": "arm-gcc-bin@9-2020-q2-update"
+}


### PR DESCRIPTION
please read https://github.com/osx-cross/homebrew-arm/pull/17#issuecomment-814276762

This PR reverts @samford work and adds aliases to keep the current behaviour

Im not sure why the aliases don't show up in the `brew search arm-gcc-bin` but they seem to work `brew info gcc@8`, any hints?