### PR TITLE
Add arm-gcc-bin@12

### DIFF
--- a/Formula/arm-gcc-bin@12.rb
+++ b/Formula/arm-gcc-bin@12.rb
@@ -1,0 +1,18 @@
+class ArmGccBinAT12 < Formula
+  desc "Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors"
+  homepage "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-darwin-arm64-arm-none-eabi.tar.xz" if Hardware::CPU.arm?
+  version "12.2.Rel1"
+  sha256 "00c0eeb57ae92332f216151ac66df6ba17d2d3b306dac86f4006006f437b2902"
+  sha256 "21a9e875250bcb0db8df4cb23dd43c94c00a1d3b98ecba9cdd6ed51586b12248" if Hardware::CPU.arm?
+
+  def install
+    bin.install Dir["bin/*"]
+    prefix.install Dir["arm-none-eabi", "include", "lib", "libexec", "share"]
+  end
+
+  test do
+    system "true"
+  end
+end


### PR DESCRIPTION
Add ARM 12.2.Rel1 toolchain.

This is the first time that both a x86 *and* Apple Silicon version of the toolchain is released and on my testing there is a ~60% speedup in using the native version over the emulated version.
But I couldn't find out through googling how to specify two different URLs for the two different architectures, perhaps that only works for bottles? Any ideas, @ladislas?

- [x] Add x86 toolchain.
- [x] Add Apple Silicon toolchain.