### PR TITLE
arm-gcc-bin@12: Make keg only.

### DIFF
--- a/Formula/arm-gcc-bin@12.rb
+++ b/Formula/arm-gcc-bin@12.rb
@@ -26,12 +26,17 @@ class ArmGccBinAT12 < Formula
     sha256 cellar: :any_skip_relocation, catalina: "f2f063698c279a5dd8f40ad0f687de6d5f8984c1e47197572e4cde6568a8422c"
   end
 
+  keg_only <<~EOS
+    it may interfere with another version of arm-gcc-bin.
+    This is useful if you want to have multiple versions installed
+  EOS
+
   def install
     bin.install Dir["bin/*"]
     prefix.install Dir["arm-none-eabi", "include", "lib", "libexec", "share"]
   end
 
   test do
-    system "true"
+    assert_match "Arm GNU Toolchain #{version}", `#{opt_prefix}/bin/arm-none-eabi-gcc --version`
   end
 end


### PR DESCRIPTION
This is untested, but seem straightforward.

Does this get automatically tested at some point or should I do more work to validate it?