### PR TITLE
arm-gcc-bin@8: Add a test to check the version.

### DIFF
--- a/Formula/arm-gcc-bin@8.rb
+++ b/Formula/arm-gcc-bin@8.rb
@@ -22,4 +22,8 @@ class ArmGccBinAT8 < Formula
     bin.install Dir["bin/*"]
     prefix.install Dir["arm-none-eabi", "lib", "share"]
   end
+
+  test do
+    assert_match "GNU Tools for Arm Embedded Processors #{version}", `#{opt_prefix}/bin/arm-none-eabi-gcc --version`
+  end
 end


### PR DESCRIPTION
This is a bit different from arm-gcc-bin@11 and arm-gcc-bin@12 because the compilers produce different results between GCC 8, 9, 10 versus GCC 11, 12.