### PR TITLE
arm-none-eabi-binutils: depend on texinfo for Ventura

### DIFF
--- a/Formula/arm-none-eabi-binutils.rb
+++ b/Formula/arm-none-eabi-binutils.rb
@@ -19,6 +19,10 @@ class ArmNoneEabiBinutils < Formula
 
   uses_from_macos "zlib"
 
+  on_ventura do
+    depends_on "texinfo" => :build
+  end
+
   def install
     # https://sourceware.org/bugzilla/show_bug.cgi?id=23424
     ENV["CXXFLAGS"] = "-std=c++11 -Wno-c++11-narrowing"


### PR DESCRIPTION
Compilation fails on M1 due to "missing" `texinfo` (for me it was installed but the build environment obviously doesn't know about it unless it's specified in the formula).