### PR TITLE
Fix style warnings

### DIFF
--- a/Formula/arm-none-eabi-binutils.rb
+++ b/Formula/arm-none-eabi-binutils.rb
@@ -47,7 +47,7 @@ class ArmNoneEabiBinutils < Formula
       system "make", "install"
     end
 
-    info.rmtree # info files conflict with native binutils
+    rm_r(info) # info files conflict with native binutils
   end
 
   test do

--- a/Formula/arm-none-eabi-gcc@8.rb
+++ b/Formula/arm-none-eabi-gcc@8.rb
@@ -259,8 +259,8 @@ class ArmNoneEabiGccAT8 < Formula
     end
 
     # info and man7 files conflict with native gcc
-    info.rmtree
-    man7.rmtree
+    rm_r(info)
+    rm_r(rmtree)
   end
 
   test do

--- a/Formula/arm-none-eabi-gcc@9.rb
+++ b/Formula/arm-none-eabi-gcc@9.rb
@@ -259,8 +259,8 @@ class ArmNoneEabiGccAT9 < Formula
     end
 
     # info and man7 files conflict with native gcc
-    info.rmtree
-    man7.rmtree
+    rm_r(info)
+    rm_r(man7)
   end
 
   test do


### PR DESCRIPTION
```
C: [Correctable] Homebrew/NoFileutilsRmrf: Use rm or rm_r instead of rm_rf, rm_f, or rmtree
```