### PR TITLE
fix: remove cxxstdlib_check , deprecated and no replacement

### DIFF
--- a/Formula/arm-none-eabi-gcc@8.rb
+++ b/Formula/arm-none-eabi-gcc@8.rb
@@ -32,9 +32,6 @@ class ArmNoneEabiGccAT8 < Formula
 
   uses_from_macos "zlib"
 
-  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
-  cxxstdlib_check :skip
-
   resource "newlib" do
     url "https://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz"
     sha256 "58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66"

--- a/Formula/arm-none-eabi-gcc@9.rb
+++ b/Formula/arm-none-eabi-gcc@9.rb
@@ -32,9 +32,6 @@ class ArmNoneEabiGccAT9 < Formula
 
   uses_from_macos "zlib"
 
-  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
-  cxxstdlib_check :skip
-
   resource "newlib" do
     url "https://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz"
     sha256 "58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66"


### PR DESCRIPTION
As with https://github.com/osx-cross/homebrew-avr/issues/368 , removing the skip on cxxstdlib_check.