### PR TITLE
arm-gcc-bin@14: upgrade to 14.3.rel1

### DIFF
--- a/Formula/arm-gcc-bin@14.rb
+++ b/Formula/arm-gcc-bin@14.rb
@@ -2,28 +2,24 @@
 
 class ArmGccBinAT14 < Formula
   @tar_file = if Hardware::CPU.arm?
-    "arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+    "14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
   else
-    "arm-gnu-toolchain-14.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+    "14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
   end
 
   @tar_file_sha = if Hardware::CPU.arm?
-    "c7c78ffab9bebfce91d99d3c24da6bf4b81c01e16cf551eb2ff9f25b9e0a3818"
+    "30f4d08b219190a37cded6aa796f4549504902c53cfc3c7e044a8490b6eba1f7"
   else
     "2d9e717dd4f7751d18936ae1365d25916534105ebcb7583039eff1092b824505"
   end
 
   desc "Pre-built GNU toolchain for Arm Cortex-M and Cortex-R processors"
-  homepage "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/#{@tar_file}"
+  homepage "https://github.com/osx-cross/homebrew-arm"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{@tar_file}"
+  # x86_64: 14.3 is not available upstream; override the version scanned from the
+  # URL so the bottle system sees a single consistent version across architectures.
+  version "14.3.rel1" unless Hardware::CPU.arm?
   sha256 @tar_file_sha
-
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-arm/releases/download/arm-gcc-bin@14-14.2.rel1"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b46c5d8026c8b1d1c410721da8259a4e1fca09aba222f644bec9eee8a5c7a850"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "908b92f97471ead3ac65f8997df61ccd22c7cf298d283e9d56e0dc10207851e0"
-    sha256 cellar: :any,                 ventura:       "5d1aa55a69ab3e028ea4d29372190365f946f176c1efdf5da1ec8034694a6f3c"
-  end
 
   depends_on "xz" unless Hardware::CPU.arm?
   depends_on "zstd" unless Hardware::CPU.arm?
@@ -34,11 +30,31 @@ class ArmGccBinAT14 < Formula
   KEG_ONLY_EOS
 
   def install
-    bin.install Dir["bin/*"]
+    bin.install (Dir["bin/*"] - ["bin/arm-none-eabi-gdb-py"])
     prefix.install Dir["arm-none-eabi", "include", "lib", "libexec", "share"]
   end
 
+  def caveats
+    if Hardware::CPU.arm?
+      <<~EOS
+        arm-none-eabi-gdb-py links against python@3.9, which is end-of-life and will
+        be removed from Homebrew in the future. It has been excluded from this
+        formula to avoid a broken linkage. If you need up-to-date GDB Python
+        scripting support, install a recompiled toolchain manually from:
+          https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases
+      EOS
+    else
+      <<~EOS
+        Note: arm-gnu-toolchain 14.3.rel1 is not available for x86_64.
+        This formula installs 14.2.rel1 on x86_64 instead.
+      EOS
+    end
+  end
+
   test do
-    assert_match "Arm GNU Toolchain #{version}".downcase, shell_output("#{opt_prefix}/bin/arm-none-eabi-gcc --version").downcase
+    # x86_64 ships 14.2.rel1 because there is no upstream 14.3 build for that arch.
+    expected_version = Hardware::CPU.arm? ? version.to_s : "14.2.rel1"
+    assert_match "Arm GNU Toolchain #{expected_version}".downcase,
+                 shell_output("#{opt_prefix}/bin/arm-none-eabi-gcc --version").downcase
   end
 end


### PR DESCRIPTION
- 14.2 was the last version with x86_64 release. I've forced the version to 14.3 for the bottling to work.
- 14.3 has arm-none-eabi-gdb-py which links against python@3.9, which will be removed form Homebrew in October 2026. Ive added a caveat.

